### PR TITLE
Auto refresh the list of pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.xcworkspacedata
 *.xcuserstate
 *.plist
+/.vs

--- a/pool-watcher/config.xml
+++ b/pool-watcher/config.xml
@@ -47,4 +47,5 @@
     </platform>
     <plugin name="cordova-plugin-statusbar" spec="^2.4.1" />
     <engine name="ios" spec="^4.5.4" />
+    <engine name="browser" spec="^5.0.3" />
 </widget>

--- a/pool-watcher/package-lock.json
+++ b/pool-watcher/package-lock.json
@@ -4,6 +4,586 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "cordova-browser": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/cordova-browser/-/cordova-browser-5.0.3.tgz",
+            "integrity": "sha1-9+VCAv3wlpQ4XXjArYckEMsJTfU=",
+            "requires": {
+                "cordova-common": "2.2.0",
+                "cordova-serve": "2.0.0",
+                "nopt": "3.0.6",
+                "shelljs": "0.5.3"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "accepts": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "requires": {
+                        "mime-types": "2.1.17",
+                        "negotiator": "0.6.1"
+                    }
+                },
+                "ansi": {
+                    "version": "0.3.1",
+                    "bundled": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "bundled": true
+                },
+                "array-flatten": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "base64-js": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "big-integer": {
+                    "version": "1.6.26",
+                    "bundled": true
+                },
+                "body-parser": {
+                    "version": "1.18.2",
+                    "bundled": true,
+                    "requires": {
+                        "bytes": "3.0.0",
+                        "content-type": "1.0.4",
+                        "debug": "2.6.9",
+                        "depd": "1.1.1",
+                        "http-errors": "1.6.2",
+                        "iconv-lite": "0.4.19",
+                        "on-finished": "2.3.0",
+                        "qs": "6.5.1",
+                        "raw-body": "2.3.2",
+                        "type-is": "1.6.15"
+                    }
+                },
+                "bplist-parser": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "big-integer": "1.6.26"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "bytes": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "compressible": {
+                    "version": "2.0.12",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.30.0"
+                    }
+                },
+                "compression": {
+                    "version": "1.7.1",
+                    "bundled": true,
+                    "requires": {
+                        "accepts": "1.3.4",
+                        "bytes": "3.0.0",
+                        "compressible": "2.0.12",
+                        "debug": "2.6.9",
+                        "on-headers": "1.0.1",
+                        "safe-buffer": "5.1.1",
+                        "vary": "1.1.2"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "content-disposition": {
+                    "version": "0.5.2",
+                    "bundled": true
+                },
+                "content-type": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "cookie": {
+                    "version": "0.3.1",
+                    "bundled": true
+                },
+                "cookie-signature": {
+                    "version": "1.0.6",
+                    "bundled": true
+                },
+                "cordova-common": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "ansi": "0.3.1",
+                        "bplist-parser": "0.1.1",
+                        "cordova-registry-mapper": "1.1.15",
+                        "elementtree": "0.1.6",
+                        "glob": "5.0.15",
+                        "minimatch": "3.0.4",
+                        "osenv": "0.1.4",
+                        "plist": "1.2.0",
+                        "q": "1.5.1",
+                        "semver": "5.4.1",
+                        "shelljs": "0.5.3",
+                        "underscore": "1.8.3",
+                        "unorm": "1.4.1"
+                    }
+                },
+                "cordova-registry-mapper": {
+                    "version": "1.1.15",
+                    "bundled": true
+                },
+                "cordova-serve": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "compression": "1.7.1",
+                        "express": "4.16.2",
+                        "open": "0.0.5",
+                        "shelljs": "0.5.3"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "depd": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "destroy": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "ee-first": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "elementtree": {
+                    "version": "0.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "sax": "0.3.5"
+                    }
+                },
+                "encodeurl": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "escape-html": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true
+                },
+                "etag": {
+                    "version": "1.8.1",
+                    "bundled": true
+                },
+                "express": {
+                    "version": "4.16.2",
+                    "bundled": true,
+                    "requires": {
+                        "accepts": "1.3.4",
+                        "array-flatten": "1.1.1",
+                        "body-parser": "1.18.2",
+                        "content-disposition": "0.5.2",
+                        "content-type": "1.0.4",
+                        "cookie": "0.3.1",
+                        "cookie-signature": "1.0.6",
+                        "debug": "2.6.9",
+                        "depd": "1.1.1",
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
+                        "finalhandler": "1.1.0",
+                        "fresh": "0.5.2",
+                        "merge-descriptors": "1.0.1",
+                        "methods": "1.1.2",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "path-to-regexp": "0.1.7",
+                        "proxy-addr": "2.0.2",
+                        "qs": "6.5.1",
+                        "range-parser": "1.2.0",
+                        "safe-buffer": "5.1.1",
+                        "send": "0.16.1",
+                        "serve-static": "1.13.1",
+                        "setprototypeof": "1.1.0",
+                        "statuses": "1.3.1",
+                        "type-is": "1.6.15",
+                        "utils-merge": "1.0.1",
+                        "vary": "1.1.2"
+                    }
+                },
+                "finalhandler": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.3.1",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "forwarded": {
+                    "version": "0.1.2",
+                    "bundled": true
+                },
+                "fresh": {
+                    "version": "0.5.2",
+                    "bundled": true
+                },
+                "glob": {
+                    "version": "5.0.15",
+                    "bundled": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "http-errors": {
+                    "version": "1.6.2",
+                    "bundled": true,
+                    "requires": {
+                        "depd": "1.1.1",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.0.3",
+                        "statuses": "1.3.1"
+                    },
+                    "dependencies": {
+                        "setprototypeof": {
+                            "version": "1.0.3",
+                            "bundled": true
+                        }
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.19",
+                    "bundled": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ipaddr.js": {
+                    "version": "1.5.2",
+                    "bundled": true
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "bundled": true
+                },
+                "media-typer": {
+                    "version": "0.3.0",
+                    "bundled": true
+                },
+                "merge-descriptors": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "methods": {
+                    "version": "1.1.2",
+                    "bundled": true
+                },
+                "mime": {
+                    "version": "1.4.1",
+                    "bundled": true
+                },
+                "mime-db": {
+                    "version": "1.30.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.17",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.30.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "negotiator": {
+                    "version": "0.6.1",
+                    "bundled": true
+                },
+                "nopt": {
+                    "version": "3.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1.1.1"
+                    }
+                },
+                "on-finished": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "ee-first": "1.1.1"
+                    }
+                },
+                "on-headers": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "open": {
+                    "version": "0.0.5",
+                    "bundled": true
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "parseurl": {
+                    "version": "1.3.2",
+                    "bundled": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "path-to-regexp": {
+                    "version": "0.1.7",
+                    "bundled": true
+                },
+                "plist": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "base64-js": "0.0.8",
+                        "util-deprecate": "1.0.2",
+                        "xmlbuilder": "4.0.0",
+                        "xmldom": "0.1.27"
+                    }
+                },
+                "proxy-addr": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "forwarded": "0.1.2",
+                        "ipaddr.js": "1.5.2"
+                    }
+                },
+                "q": {
+                    "version": "1.5.1",
+                    "bundled": true
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "bundled": true
+                },
+                "range-parser": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "raw-body": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "bytes": "3.0.0",
+                        "http-errors": "1.6.2",
+                        "iconv-lite": "0.4.19",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "bundled": true
+                },
+                "sax": {
+                    "version": "0.3.5",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "bundled": true
+                },
+                "send": {
+                    "version": "0.16.1",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "depd": "1.1.1",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
+                        "fresh": "0.5.2",
+                        "http-errors": "1.6.2",
+                        "mime": "1.4.1",
+                        "ms": "2.0.0",
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.3.1"
+                    }
+                },
+                "serve-static": {
+                    "version": "1.13.1",
+                    "bundled": true,
+                    "requires": {
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "parseurl": "1.3.2",
+                        "send": "0.16.1"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "shelljs": {
+                    "version": "0.5.3",
+                    "bundled": true
+                },
+                "statuses": {
+                    "version": "1.3.1",
+                    "bundled": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "type-is": {
+                    "version": "1.6.15",
+                    "bundled": true,
+                    "requires": {
+                        "media-typer": "0.3.0",
+                        "mime-types": "2.1.17"
+                    }
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "bundled": true
+                },
+                "unorm": {
+                    "version": "1.4.1",
+                    "bundled": true
+                },
+                "unpipe": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "utils-merge": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "vary": {
+                    "version": "1.1.2",
+                    "bundled": true
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "xmlbuilder": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "lodash": "3.10.1"
+                    }
+                },
+                "xmldom": {
+                    "version": "0.1.27",
+                    "bundled": true
+                }
+            }
+        },
         "cordova-ios": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-4.5.4.tgz",
@@ -311,6 +891,11 @@
                     "bundled": true
                 }
             }
+        },
+        "cordova-plugin-file": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-file/-/cordova-plugin-file-6.0.1.tgz",
+            "integrity": "sha1-SWBrjBWlaI1HKPkuSnMloGHeB/U="
         },
         "cordova-plugin-statusbar": {
             "version": "2.4.1",

--- a/pool-watcher/package-lock.json
+++ b/pool-watcher/package-lock.json
@@ -892,11 +892,6 @@
                 }
             }
         },
-        "cordova-plugin-file": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/cordova-plugin-file/-/cordova-plugin-file-6.0.1.tgz",
-            "integrity": "sha1-SWBrjBWlaI1HKPkuSnMloGHeB/U="
-        },
         "cordova-plugin-statusbar": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/cordova-plugin-statusbar/-/cordova-plugin-statusbar-2.4.1.tgz",

--- a/pool-watcher/package.json
+++ b/pool-watcher/package.json
@@ -10,6 +10,7 @@
     "author": "derp-derp-derp",
     "license": "Apache-2.0",
     "dependencies": {
+        "cordova-browser": "^5.0.3",
         "cordova-ios": "^4.5.4",
         "cordova-plugin-statusbar": "^2.4.1",
         "cordova-plugin-whitelist": "^1.3.3"
@@ -20,7 +21,8 @@
             "cordova-plugin-statusbar": {}
         },
         "platforms": [
-            "ios"
+            "ios",
+            "browser"
         ]
     }
 }

--- a/pool-watcher/plugins/browser.json
+++ b/pool-watcher/plugins/browser.json
@@ -1,0 +1,18 @@
+{
+  "prepare_queue": {
+    "installed": [],
+    "uninstalled": []
+  },
+  "config_munge": {
+    "files": {}
+  },
+  "installed_plugins": {
+    "cordova-plugin-statusbar": {
+      "PACKAGE_NAME": "lol.turtlecoin.poolwatcher"
+    },
+    "cordova-plugin-whitelist": {
+      "PACKAGE_NAME": "lol.turtlecoin.poolwatcher"
+    }
+  },
+  "dependent_plugins": {}
+}

--- a/pool-watcher/www/js/controllers.js
+++ b/pool-watcher/www/js/controllers.js
@@ -10,6 +10,19 @@ angular.module('tc.controllers', [])
     var storage_selected_pool_index = storage.getItem('selected_pool_index');
     var wallet_input = $('#walletAddress');
     var pool_input = $('#poolApiUrl');
+
+    var doUpdatePools = function () {   
+        $.ajaxSetup({ cache: false });
+        // TODO: You'll want to change this to the main repo or host somewhere else.
+        $.getJSON('https://raw.githubusercontent.com/hensleyrob/ios-pool-monitor/master/pools.json', function (data) {
+            $.each(data, function (key, value) {
+                pool_input.append('<option value="' + key + '|' + value.url + '">' + key + '</option>');
+            });
+        });
+    };
+
+    doUpdatePools();
+
     var sendToDashboard = function(wallet, pool, apply=null)
     {
         var full_path = '/dashboard/' + pool + '/' + wallet;

--- a/pool-watcher/www/views/home.html
+++ b/pool-watcher/www/views/home.html
@@ -1,30 +1,23 @@
 <div id="homeContainer">
 
     <img src="img/home-logo.png" width="256" id="mainLogo">
-    
-    <div class="RobotoBold titleText">Select your pool</span><br><br>
-    <select class="Roboto" id="poolApiUrl">
-        <option value="us.turtlepool.space|http://us.turtlepool.space/api/" class="Roboto">us.turtlepool.space</option>
-        <option value="z-pool.com|https://z-pool.com/api/" class="Roboto">z-pool.com</option>
-        <option value="slowandsteady.fun|http://slowandsteady.fun:8119/" class="Roboto">slowandsteady.fun</option>
-        <option value="eu.turtlepool.space|http://eu.turtlepool.space/api/" class="Roboto">eu.turtlepool.space</option>
-        <option value="hk.turtlepool.space|http://hk.turtlepool.space/api/" class="Roboto">hk.turtlepool.space</option>
-        <option value="ny.minetrtl.us|http://ny.minetrtl.us:8117/" class="Roboto">ny.minetrtl.us</option>
-        <option value="auspool.turtleco.in|http://auspool.turtleco.in/api/" class="Roboto">auspool.turtleco.in</option>
-        <option value="pool.turtleco.in|http://us.turtlepool.space/api/" class="Roboto">pool.turtleco.in</option>
-        <option value="trtlpool.ninja|http://trtlpool.ninja/api/" class="Roboto">trtlpool.ninja</option>
-        <option value="mine.tortugamor.cf|http://tortugamor.cf:8117/" class="Roboto">mine.tortugamor.cf</option>
-        <option value="cryptoknight.cc|http://78.46.85.142:6229/" class="Roboto">cryptoknight.cc</option>
-        <option value="trtl.ninja|https://trtl.ninja/api/" class="Roboto">trtl.ninja</option>
-        <option value="turtlecoinpool.ml|https://turtlecoinpool.ml:8443/" class="Roboto">turtlecoinpool.ml</option>
-        <option value="trtl.mine2gether.com|https://trtl.mine2gether.com/api/" class="Roboto">trtl.mine2gether.com</option>
-    </select>
-    <br><br>
-        
-    <div class="RobotoBold titleText">Enter your wallet address</span><br><br>
-        
-    <input id="walletAddress" type="text" onblur="if (this.value == ''){this.value='Wallet address'}" onfocus="this.value=''" value="Wallet address" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"><br><br>
-    
-    <img src="./img/home-go-button.png" id="submitPool" height="36">
+
+    <div class="RobotoBold titleText">
+        <span>Select your pool</span><br><br>
+
+        <select class="Roboto" id="poolApiUrl" />
+
+        <br><br>
+
+        <div class="RobotoBold titleText">
+            <span>Enter your wallet address</span><br><br>
+
+            <input id="walletAddress" type="text" onblur="if (this.value == ''){this.value='Wallet address'}" onfocus="this.value=''" value="Wallet address" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"><br><br>
+
+            <img src="./img/home-go-button.png" id="submitPool" height="36">
+
+        </div>
+
+    </div>
 
 </div>

--- a/pools.json
+++ b/pools.json
@@ -1,0 +1,44 @@
+{
+	"us.turtlepool.space" : {
+		"url" : "http://us.turtlepool.space/api/"
+	},
+	"z-pool.com" : {
+		"url" : "https://z-pool.com/api/"
+	},
+	"slowandsteady.fun" : {
+		"url" : "http://slowandsteady.fun:8119/"
+	},
+	"eu.turtlepool.space" : {
+		"url" : "http://eu.turtlepool.space/api/"
+	},
+	"hk.turtlepool.space" : {
+		"url" : "http://hk.turtlepool.space/api/"
+	},
+	"ny.minetrtl.us" : {
+		"url" : "http://ny.minetrtl.us:8117/"
+	},
+	"auspool.turtleco.in" : {
+		"url" : "http://auspool.turtleco.in/api/"
+	},
+	"pool.turtleco.in" : {
+		"url" : "http://us.turtlepool.space/api/"
+	},
+	"trtlpool.ninja" : {
+		"url" : "http://trtlpool.ninja/api/"
+	},
+	"mine.tortugamor.cf" : {
+		"url" : "http://tortugamor.cf:8117/"
+	},
+	"cryptoknight.cc" : {
+		"url" : "http://78.46.85.142:6229/"
+	},
+	"trtl.ninja" : {
+		"url" : "https://trtl.ninja/api/"
+	},
+	"turtlecoinpool.ml" : {
+		"url" : "https://turtlecoinpool.ml:8443/"
+	},
+	"trtl.mine2gether.com" : {
+		"url" : "https://trtl.mine2gether.com/api/"
+	}
+}


### PR DESCRIPTION
Auto refresh the list of pools from a json file hosted on GitHub (you'll need to change the URL to not point at my repo). This will allow for adding/removing/editing pools without having to resubmit the app to Apple for approval.  To change the URL of the pools.json, just add it to GitHub and then add ?raw=true onto the end of the URL.